### PR TITLE
Persistence

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -91,7 +91,7 @@ func (app *MerkleEyesApp) CheckTx(tx []byte) abci.Result {
 	return app.doTx(tree, tx)
 }
 
-func (app *MerkleEyesApp) DoTx(tree merkle.Tree, tx []byte) abci.Result {
+func (app *MerkleEyesApp) doTx(tree merkle.Tree, tx []byte) abci.Result {
 	if len(tx) == 0 {
 		return abci.ErrEncodingError.SetLog("Tx length cannot be zero")
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -14,9 +14,8 @@ import (
 )
 
 type MerkleEyesApp struct {
-	state      State
-	db         dbm.DB
-	persistent bool
+	state State
+	db    dbm.DB
 }
 
 //Database Keys
@@ -39,9 +38,8 @@ func NewMerkleEyesApp(dbName string, cache int) *MerkleEyesApp {
 			nil,
 		)
 		return &MerkleEyesApp{
-			state:      NewState(tree),
-			db:         nil,
-			persistent: false,
+			state: NewState(tree, false),
+			db:    nil,
 		}
 	}
 
@@ -65,10 +63,8 @@ func NewMerkleEyesApp(dbName string, cache int) *MerkleEyesApp {
 	tree.Load(db.Get(saveKey))
 
 	return &MerkleEyesApp{
-		state:      NewState(tree),
-		tree:       tree,
-		db:         db,
-		persistent: true,
+		state: NewState(tree, true),
+		db:    db,
 	}
 }
 
@@ -159,8 +155,8 @@ func (app *MerkleEyesApp) Commit() abci.Result {
 
 	hash := app.state.Commit()
 
-	if app.persistent {
-		app.db.Set(saveKey, app.tree.Save())
+	if app.db != nil {
+		app.db.Set(saveKey, hash)
 	}
 
 	if app.state.Committed().Size() == 0 {

--- a/app/app.go
+++ b/app/app.go
@@ -23,11 +23,13 @@ var saveKey []byte = []byte{0x00} //Key for merkle tree save value db values
 var prefix []byte = []byte{0x01}  //Prefix byte for all data saved in the merkle tree, used to prevent key collision with the savekey record
 
 //App Usage Keys
-const WriteSet byte = 0x01
-const WriteRem byte = 0x02
-const ReadByKey byte = 0x01
-const ReadByIndex byte = 0x02
-const ReadSize byte = 0x03
+const (
+	WriteSet    byte = 0x01
+	WriteRem    byte = 0x02
+	ReadByKey   byte = 0x01
+	ReadByIndex byte = 0x02
+	ReadSize    byte = 0x03
+)
 
 func NewMerkleEyesApp(dbName string, cache int) *MerkleEyesApp {
 
@@ -47,7 +49,7 @@ func NewMerkleEyesApp(dbName string, cache int) *MerkleEyesApp {
 	present, _ := IsDirEmpty(path.Join(dbName, dbName+".db"))
 
 	//open the db, if the db doesn't exist it will be created
-	db := dbm.NewDB(dbName, dbm.DBBackendLevelDB, dbName)
+	db := dbm.NewDB(dbName, dbm.LevelDBBackendStr, dbName)
 
 	// Load Tree
 	tree := merkle.NewIAVLTree(cache, db)
@@ -103,12 +105,12 @@ func (app *MerkleEyesApp) SetOption(key string, value string) (log string) {
 
 func (app *MerkleEyesApp) DeliverTx(tx []byte) abci.Result {
 	tree := app.state.Append()
-	return app.DoTx(tree, tx)
+	return app.doTx(tree, tx)
 }
 
 func (app *MerkleEyesApp) CheckTx(tx []byte) abci.Result {
 	tree := app.state.Check()
-	return app.DoTx(tree, tx)
+	return app.doTx(tree, tx)
 }
 
 func (app *MerkleEyesApp) DoTx(tree merkle.Tree, tx []byte) abci.Result {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -11,7 +11,7 @@ import (
 func makeSet(key, value []byte) []byte {
 	tx := make([]byte, 1+wire.ByteSliceSize(key)+wire.ByteSliceSize(value))
 	buf := tx
-	buf[0] = 0x01 // Set TypeByte
+	buf[0] = WriteSet // Set TypeByte
 	buf = buf[1:]
 	n, err := wire.PutByteSlice(buf, key)
 	if err != nil {
@@ -28,7 +28,7 @@ func makeSet(key, value []byte) []byte {
 func makeRemove(key []byte) []byte {
 	tx := make([]byte, 1+wire.ByteSliceSize(key))
 	buf := tx
-	buf[0] = 0x02 // Set TypeByte
+	buf[0] = WriteRem // Set TypeByte
 	buf = buf[1:]
 	_, err := wire.PutByteSlice(buf, key)
 	if err != nil {
@@ -40,7 +40,7 @@ func makeRemove(key []byte) []byte {
 func makeQuery(key []byte) []byte {
 	tx := make([]byte, 1+wire.ByteSliceSize(key))
 	buf := tx
-	buf[0] = 0x01 // Set TypeByte
+	buf[0] = ReadByKey // Set TypeByte
 	buf = buf[1:]
 	_, err := wire.PutByteSlice(buf, key)
 	if err != nil {
@@ -52,7 +52,7 @@ func makeQuery(key []byte) []byte {
 func TestAppQueries(t *testing.T) {
 	assert := assert.New(t)
 
-	app := NewMerkleEyesApp()
+	app := NewMerkleEyesApp("", 0)
 	info := app.Info().Data
 	assert.Equal("size:0", info)
 	com := app.Commit()

--- a/app/state.go
+++ b/app/state.go
@@ -5,16 +5,18 @@ import merkle "github.com/tendermint/go-merkle"
 // State represents the app states, separating the commited state (for queries)
 // from the working state (for CheckTx and AppendTx)
 type State struct {
-	committed merkle.Tree
-	deliverTx merkle.Tree
-	checkTx   merkle.Tree
+	committed  merkle.Tree
+	deliverTx  merkle.Tree
+	checkTx    merkle.Tree
+	persistent bool
 }
 
 func NewState(tree merkle.Tree, persistent bool) State {
 	return State{
-		committed: tree,
-		deliverTx: tree.Copy(),
-		checkTx:   tree.Copy(),
+		committed:  tree,
+		deliverTx:  tree.Copy(),
+		checkTx:    tree.Copy(),
+		persistent: persistent,
 	}
 }
 
@@ -34,8 +36,13 @@ func (s State) Check() merkle.Tree {
 // starts new Append/Check state, and
 // returns the hash for the commit
 func (s *State) Commit() []byte {
-	// TODO: use save, broken for now, cuz it requires a backing db
-	hash := s.deliverTx.Hash()
+	var hash []byte
+	if s.persistent {
+		hash = s.deliverTx.Save()
+	} else {
+		hash = s.deliverTx.Hash()
+	}
+
 	s.committed = s.deliverTx
 	s.deliverTx = s.committed.Copy()
 	s.checkTx = s.committed.Copy()

--- a/app/state.go
+++ b/app/state.go
@@ -10,7 +10,7 @@ type State struct {
 	checkTx   merkle.Tree
 }
 
-func NewState(tree merkle.Tree) State {
+func NewState(tree merkle.Tree, persistent bool) State {
 	return State{
 		committed: tree,
 		deliverTx: tree.Copy(),

--- a/client/client.go
+++ b/client/client.go
@@ -5,6 +5,7 @@ import (
 	abci "github.com/tendermint/abci/types"
 	"github.com/tendermint/go-wire"
 	"github.com/tendermint/merkleeyes/app"
+	cmn "github.com/tendermint/merkleeyes/common"
 )
 
 type Client struct {

--- a/client/client.go
+++ b/client/client.go
@@ -36,7 +36,7 @@ func NewLocalClient() *Client {
 }
 
 func (client *Client) GetSync(key []byte) (res abci.Result) {
-	key = app.AddPrefix(key)
+	key = cmn.AddPrefix(key)
 	query := make([]byte, 1+wire.ByteSliceSize(key))
 	buf := query
 	buf[0] = app.ReadByKey // Get TypeByte
@@ -51,7 +51,7 @@ func (client *Client) GetSync(key []byte) (res abci.Result) {
 }
 
 func (client *Client) SetSync(key []byte, value []byte) (res abci.Result) {
-	key = app.AddPrefix(key)
+	key = cmn.AddPrefix(key)
 	tx := make([]byte, 1+wire.ByteSliceSize(key)+wire.ByteSliceSize(value))
 	buf := tx
 	buf[0] = app.WriteSet // Set TypeByte
@@ -69,7 +69,7 @@ func (client *Client) SetSync(key []byte, value []byte) (res abci.Result) {
 }
 
 func (client *Client) RemSync(key []byte) (res abci.Result) {
-	key = app.AddPrefix(key)
+	key = cmn.AddPrefix(key)
 	tx := make([]byte, 1+wire.ByteSliceSize(key))
 	buf := tx
 	buf[0] = app.WriteRem // Rem TypeByte

--- a/client/client.go
+++ b/client/client.go
@@ -38,7 +38,7 @@ func (client *Client) GetSync(key []byte) (res abci.Result) {
 	key = app.AddPrefix(key)
 	query := make([]byte, 1+wire.ByteSliceSize(key))
 	buf := query
-	buf[0] = 0x01 // Get TypeByte
+	buf[0] = app.ReadByKey // Get TypeByte
 	buf = buf[1:]
 	wire.PutByteSlice(buf, key)
 	res = client.QuerySync(query)
@@ -53,7 +53,7 @@ func (client *Client) SetSync(key []byte, value []byte) (res abci.Result) {
 	key = app.AddPrefix(key)
 	tx := make([]byte, 1+wire.ByteSliceSize(key)+wire.ByteSliceSize(value))
 	buf := tx
-	buf[0] = 0x01 // Set TypeByte
+	buf[0] = app.WriteSet // Set TypeByte
 	buf = buf[1:]
 	n, err := wire.PutByteSlice(buf, key)
 	if err != nil {
@@ -71,7 +71,7 @@ func (client *Client) RemSync(key []byte) (res abci.Result) {
 	key = app.AddPrefix(key)
 	tx := make([]byte, 1+wire.ByteSliceSize(key))
 	buf := tx
-	buf[0] = 0x02 // Rem TypeByte
+	buf[0] = app.WriteRem // Rem TypeByte
 	buf = buf[1:]
 	_, err := wire.PutByteSlice(buf, key)
 	if err != nil {

--- a/client/client.go
+++ b/client/client.go
@@ -35,6 +35,7 @@ func NewLocalClient() *Client {
 }
 
 func (client *Client) GetSync(key []byte) (res abci.Result) {
+	key = app.AddPrefix(key)
 	query := make([]byte, 1+wire.ByteSliceSize(key))
 	buf := query
 	buf[0] = 0x01 // Get TypeByte
@@ -49,6 +50,7 @@ func (client *Client) GetSync(key []byte) (res abci.Result) {
 }
 
 func (client *Client) SetSync(key []byte, value []byte) (res abci.Result) {
+	key = app.AddPrefix(key)
 	tx := make([]byte, 1+wire.ByteSliceSize(key)+wire.ByteSliceSize(value))
 	buf := tx
 	buf[0] = 0x01 // Set TypeByte
@@ -66,6 +68,7 @@ func (client *Client) SetSync(key []byte, value []byte) (res abci.Result) {
 }
 
 func (client *Client) RemSync(key []byte) (res abci.Result) {
+	key = app.AddPrefix(key)
 	tx := make([]byte, 1+wire.ByteSliceSize(key))
 	buf := tx
 	buf[0] = 0x02 // Rem TypeByte

--- a/client/client.go
+++ b/client/client.go
@@ -27,7 +27,7 @@ func NewClient(addr, abci string) (*Client, error) {
 }
 
 func NewLocalClient() *Client {
-	eyesApp := app.NewMerkleEyesApp()
+	eyesApp := app.NewMerkleEyesApp("", 0) //TODO does this make sense? create a non-persistent instance if a local client?
 	abciClient := abcicli.NewLocalClient(nil, eyesApp)
 	return &Client{
 		Client: abciClient,

--- a/cmd/merkleeyes/merkleeyes.go
+++ b/cmd/merkleeyes/merkleeyes.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	. "github.com/tendermint/go-common"
 	"github.com/tendermint/abci/server"
+	. "github.com/tendermint/go-common"
 	"github.com/urfave/cli"
 	"os"
 
@@ -28,6 +28,11 @@ func main() {
 					Value: "socket",
 					Usage: "socket | grpc",
 				},
+				cli.StringFlag{
+					Name:  "dbPath",
+					Value: "",
+					Usage: "specifies relative path for saving db file for persistence",
+				},
 			},
 			Action: func(c *cli.Context) {
 				cmdServer(app, c)
@@ -43,7 +48,8 @@ func main() {
 func cmdServer(app *cli.App, c *cli.Context) {
 	addr := c.String("address")
 	abci := c.String("abci")
-	mApp := application.NewMerkleEyesApp()
+	dbPath := c.String("dbPath")
+	mApp := application.NewMerkleEyesApp(dbPath)
 
 	// Start the listener
 	s, err := server.NewServer(addr, abci, mApp)

--- a/cmd/merkleeyes/merkleeyes.go
+++ b/cmd/merkleeyes/merkleeyes.go
@@ -6,7 +6,7 @@ import (
 	"github.com/urfave/cli"
 	"os"
 
-	application "github.com/tendermint/merkleeyes/app"
+	mApp "github.com/tendermint/merkleeyes/app"
 )
 
 func main() {
@@ -56,10 +56,10 @@ func cmdServer(app *cli.App, c *cli.Context) {
 	dbName := c.String("dbName")
 	cache := c.Int("cache")
 
-	mApp := application.NewMerkleEyesApp(dbName, cache)
-
 	// Start the listener
+	appInstance := mApp.NewMerkleEyesApp(dbName, cache)
 	s, err := server.NewServer(addr, abci, mApp)
+
 	if err != nil {
 		Exit(err.Error())
 	}
@@ -67,6 +67,7 @@ func cmdServer(app *cli.App, c *cli.Context) {
 	// Wait forever
 	TrapSignal(func() {
 		// Cleanup
+		appInstance.CloseDb()
 		s.Stop()
 	})
 }

--- a/cmd/merkleeyes/merkleeyes.go
+++ b/cmd/merkleeyes/merkleeyes.go
@@ -29,9 +29,14 @@ func main() {
 					Usage: "socket | grpc",
 				},
 				cli.StringFlag{
-					Name:  "dbPath",
-					Value: "",
-					Usage: "specifies relative path for saving db file for persistence",
+					Name:  "dbName",
+					Value: "", //empty strings create non-persistent db
+					Usage: "database name",
+				},
+				cli.IntFlag{
+					Name:  "cache",
+					Value: 0,
+					Usage: "database cache size",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -48,8 +53,10 @@ func main() {
 func cmdServer(app *cli.App, c *cli.Context) {
 	addr := c.String("address")
 	abci := c.String("abci")
-	dbPath := c.String("dbPath")
-	mApp := application.NewMerkleEyesApp(dbPath)
+	dbName := c.String("dbName")
+	cache := c.Int("cache")
+
+	mApp := application.NewMerkleEyesApp(dbName, cache)
 
 	// Start the listener
 	s, err := server.NewServer(addr, abci, mApp)

--- a/cmd/merkleeyes/merkleeyes.go
+++ b/cmd/merkleeyes/merkleeyes.go
@@ -6,7 +6,7 @@ import (
 	"github.com/urfave/cli"
 	"os"
 
-	mApp "github.com/tendermint/merkleeyes/app"
+	application "github.com/tendermint/merkleeyes/app"
 )
 
 func main() {
@@ -57,7 +57,7 @@ func cmdServer(app *cli.App, c *cli.Context) {
 	cache := c.Int("cache")
 
 	// Start the listener
-	appInstance := mApp.NewMerkleEyesApp(dbName, cache)
+	mApp := application.NewMerkleEyesApp(dbName, cache)
 	s, err := server.NewServer(addr, abci, mApp)
 
 	if err != nil {
@@ -67,7 +67,7 @@ func cmdServer(app *cli.App, c *cli.Context) {
 	// Wait forever
 	TrapSignal(func() {
 		// Cleanup
-		appInstance.CloseDb()
+		mApp.CloseDb()
 		s.Stop()
 	})
 }

--- a/common/common.go
+++ b/common/common.go
@@ -1,0 +1,27 @@
+package common
+
+import (
+	"io"
+	"os"
+)
+
+var prefix []byte = []byte{0x01} //Prefix byte for all data saved in the merkle tree, used to prevent key collision with the savekey record
+
+//append the prefix before the key, used to prevent db collisions
+func AddPrefix(key []byte) []byte {
+	return append(prefix, key...)
+}
+
+func IsDirEmpty(name string) (bool, error) {
+	f, err := os.Open(name)
+	if err != nil {
+		return true, err //folder is non-existent
+	}
+	defer f.Close()
+
+	_, err = f.Readdirnames(1) // Or f.Readdir(1)
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err // Either not empty or error, suits both cases
+}

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"bytes"
 	"os"
 	"testing"
 

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -49,13 +49,7 @@ func testProcedure(t *testing.T, addr, dbName string, cache int, testPersistence
 
 	// Create client
 	cli, err := eyes.NewClient(addr, abciType)
-
-	//Overwrite previous defer statement
-	defer func() { //Close the database, server, and client
-		mApp.CloseDb()
-		s.Stop()
-		cli.Stop()
-	}()
+	defer cli.Stop()
 	checkErr(err)
 
 	if !testPersistence {

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -64,23 +64,28 @@ func testProcedure(t *testing.T, addr, dbName string, cache int, testPersistence
 		get(t, cli, "foa", "", "")
 		get(t, cli, "foz", "", "")
 		rem(t, cli, "foo")
-		// Empty
-		get(t, cli, "foo", "", "")
+
+		// Not empty until commit....
+		get(t, cli, "foo", "FOO", "")
 		commit(t, cli, "")
+		get(t, cli, "foo", "", "")
+
 		// Set foo1, foo2, foo3...
 		set(t, cli, "foo1", "1")
 		set(t, cli, "foo2", "2")
 		set(t, cli, "foo3", "3")
 		set(t, cli, "foo1", "4")
+		// nothing commited yet...
+		get(t, cli, "foo1", "", "")
+		commit(t, cli, "FB3B1F101D5059C75455F8476A772CDFCF12B440")
+		// now we got info
 		get(t, cli, "foo1", "4", "")
 		get(t, cli, "foo2", "2", "")
 		get(t, cli, "foo3", "3", "")
-		commit(t, cli, "FB3B1F101D5059C75455F8476A772CDFCF12B440")
 	} else {
 		get(t, cli, "foo1", "4", "")
 		get(t, cli, "foo2", "2", "")
 		get(t, cli, "foo3", "3", "")
-
 	}
 
 	if clearRecords {

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -13,13 +13,21 @@ import (
 
 var abciType = "socket"
 
-func TestClient(t *testing.T) {
+func TestNonPersistent(t *testing.T) {
+	testProcedure(t, "tcp://127.0.0.1:46659", "", 0, false, true)
+}
 
-	addr := "tcp://127.0.0.1:46659"
+func TestPersistent(t *testing.T) {
+	testProcedure(t, "tcp://127.0.0.1:46659", "", 0, false, false)
+	//testProcedure(t, "tcp://127.0.0.1:46669", "", 0, true, true)
+}
+
+func testProcedure(t *testing.T, addr, dbName string, cache int, testPersistence, clearRecords bool) {
 
 	// Start the listener
-	mApp := app.NewMerkleEyesApp("", 0)
+	mApp := app.NewMerkleEyesApp(dbName, cache)
 	s, err := server.NewServer(addr, abciType, mApp)
+
 	if err != nil {
 		t.Fatal(err.Error())
 		return
@@ -34,39 +42,45 @@ func TestClient(t *testing.T) {
 	}
 	defer cli.Stop()
 
-	// Empty
-	commit(t, cli, "")
-	get(t, cli, "foo", "", "")
-	get(t, cli, "bar", "", "")
-	// Set foo=FOO
-	set(t, cli, "foo", "FOO")
-	commit(t, cli, "68DECA470D80183B5E979D167E3DD0956631A952")
-	get(t, cli, "foo", "FOO", "")
-	get(t, cli, "foa", "", "")
-	get(t, cli, "foz", "", "")
-	rem(t, cli, "foo")
-	// Not empty until committed...
-	get(t, cli, "foo", "FOO", "")
-	commit(t, cli, "")
-	get(t, cli, "foo", "", "")
-	commit(t, cli, "")
-	// Set foo1, foo2, foo3...
-	set(t, cli, "foo1", "1")
-	set(t, cli, "foo2", "2")
-	set(t, cli, "foo3", "3")
-	set(t, cli, "foo1", "4")
-	// nothing commited yet...
-	get(t, cli, "foo1", "", "")
-	commit(t, cli, "45B7F856A16CB2F8BB9A4A25587FC71D062BD631")
-	// now we got info
-	get(t, cli, "foo1", "4", "")
-	get(t, cli, "foo2", "2", "")
-	get(t, cli, "foo3", "3", "")
-	rem(t, cli, "foo3")
-	rem(t, cli, "foo2")
-	rem(t, cli, "foo1")
-	// Empty
-	commit(t, cli, "")
+	if !testPersistence {
+		// Empty
+		commit(t, cli, "")
+		get(t, cli, "foo", "", "")
+		get(t, cli, "bar", "", "")
+		// Set foo=FOO
+		set(t, cli, "foo", "FOO")
+
+		commit(t, cli, "F5EB586B3499DA359ECF3BD2B2DCCE8C97C5E479")
+		get(t, cli, "foo", "FOO", "")
+		get(t, cli, "foa", "", "")
+		get(t, cli, "foz", "", "")
+		rem(t, cli, "foo")
+		// Empty
+		get(t, cli, "foo", "", "")
+		commit(t, cli, "")
+		// Set foo1, foo2, foo3...
+		set(t, cli, "foo1", "1")
+		set(t, cli, "foo2", "2")
+		set(t, cli, "foo3", "3")
+		set(t, cli, "foo1", "4")
+		get(t, cli, "foo1", "4", "")
+		get(t, cli, "foo2", "2", "")
+		get(t, cli, "foo3", "3", "")
+		commit(t, cli, "FB3B1F101D5059C75455F8476A772CDFCF12B440")
+	} else {
+		get(t, cli, "foo1", "4", "")
+		get(t, cli, "foo2", "2", "")
+		get(t, cli, "foo3", "3", "")
+
+	}
+
+	if clearRecords {
+		rem(t, cli, "foo3")
+		rem(t, cli, "foo2")
+		rem(t, cli, "foo1")
+		// Empty
+		commit(t, cli, "")
+	}
 }
 
 func get(t *testing.T, cli *eyes.Client, key string, value string, err string) {

--- a/tests/client_test.go
+++ b/tests/client_test.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/tendermint/abci/server"
 	. "github.com/tendermint/go-common"
 	"github.com/tendermint/merkleeyes/app"
 	eyes "github.com/tendermint/merkleeyes/client"
-	"github.com/tendermint/abci/server"
 )
 
 var abciType = "socket"
@@ -18,7 +18,7 @@ func TestClient(t *testing.T) {
 	addr := "tcp://127.0.0.1:46659"
 
 	// Start the listener
-	mApp := app.NewMerkleEyesApp()
+	mApp := app.NewMerkleEyesApp("", 0)
 	s, err := server.NewServer(addr, abciType, mApp)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -3,10 +3,10 @@ package testutil
 import (
 	"testing"
 
+	"github.com/tendermint/abci/server"
 	. "github.com/tendermint/go-common"
 	"github.com/tendermint/merkleeyes/app"
 	eyes "github.com/tendermint/merkleeyes/client"
-	"github.com/tendermint/abci/server"
 )
 
 var abciType = "socket"
@@ -16,7 +16,7 @@ func CreateEyes(t *testing.T) (svr Service, cli *eyes.Client) {
 	addr := "unix://eyes.sock"
 
 	// Start the listener
-	mApp := app.NewMerkleEyesApp()
+	mApp := app.NewMerkleEyesApp("", 0)
 	svr, err := server.NewServer(addr, abciType, mApp)
 	if err != nil {
 		(err.Error())


### PR DESCRIPTION
Closes #7.
a) Added flags and functionality for a relative db name used for persistence (use "" for non-persistence) as well as cache size for db. 
b) Added prefix to all data in the merkle to avoid collisions with merkle save hash which is also saved in the database. 
c) Updated client tests for persistence (bug fix - defer statements were overwriting each other), also updated the expected hashes within the client tests. 
d) Added variables for representing get/set/remove application actions... left the byte signatures as they previously were in the application. (used under app.go and client.go)

Questions left to address:
1) What is the purpose of testutil? I updated the code, but it's not a fully formed test file, and not called anywhere else... should we remove or update? (maybe separate PR) 
2) Not 100% comfortable with my understanding of the client package used here - do you think it makes sense to add collision-preventing prefixes as I've done under Client.go lines 38, 54, 73? It's an absolute requirement under the app.go file a believe just not positive for this case. 