### PR TITLE
Tmsp proof

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.swo
 *.pyc
 test.sock
+vendor

--- a/app/app.go
+++ b/app/app.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	. "github.com/tendermint/go-common"
-	db "github.com/tendermint/go-db"
 	"github.com/tendermint/go-merkle"
 	"github.com/tendermint/go-wire"
 	tmsp "github.com/tendermint/tmsp/types"
@@ -16,8 +15,8 @@ type MerkleEyesApp struct {
 
 func NewMerkleEyesApp() *MerkleEyesApp {
 	tree := merkle.NewIAVLTree(
-		10,
-		db.NewMemDB(),
+		0,
+		nil,
 	)
 	return &MerkleEyesApp{state: NewState(tree)}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+
 	. "github.com/tendermint/go-common"
 	"github.com/tendermint/go-merkle"
 	"github.com/tendermint/go-wire"
@@ -149,4 +150,10 @@ func (app *MerkleEyesApp) Query(query []byte) tmsp.Result {
 	default:
 		return tmsp.ErrUnknownRequest.SetLog(Fmt("Unexpected Query type byte %X", typeByte))
 	}
+}
+
+func (app *MerkleEyesApp) Proof(key []byte) tmsp.Result {
+	// TODO: we really need to return some sort of error if not there... but what?
+	proof, _ := app.tree.Proof(key)
+	return tmsp.NewResultOK(proof, "")
 }

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -1,0 +1,123 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	merkle "github.com/tendermint/go-merkle"
+	wire "github.com/tendermint/go-wire"
+)
+
+func makeSet(key, value []byte) []byte {
+	tx := make([]byte, 1+wire.ByteSliceSize(key)+wire.ByteSliceSize(value))
+	buf := tx
+	buf[0] = 0x01 // Set TypeByte
+	buf = buf[1:]
+	n, err := wire.PutByteSlice(buf, key)
+	if err != nil {
+		panic(err)
+	}
+	buf = buf[n:]
+	n, err = wire.PutByteSlice(buf, value)
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+func makeRemove(key []byte) []byte {
+	tx := make([]byte, 1+wire.ByteSliceSize(key))
+	buf := tx
+	buf[0] = 0x02 // Set TypeByte
+	buf = buf[1:]
+	_, err := wire.PutByteSlice(buf, key)
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+func makeQuery(key []byte) []byte {
+	tx := make([]byte, 1+wire.ByteSliceSize(key))
+	buf := tx
+	buf[0] = 0x01 // Set TypeByte
+	buf = buf[1:]
+	_, err := wire.PutByteSlice(buf, key)
+	if err != nil {
+		panic(err)
+	}
+	return tx
+}
+
+func TestAppQueries(t *testing.T) {
+	assert := assert.New(t)
+
+	app := NewMerkleEyesApp()
+	info := app.Info()
+	assert.Equal("size:0", info)
+	com := app.Commit()
+	assert.Equal([]byte(nil), com.Data)
+
+	// prepare some actions
+	key, value := []byte("foobar"), []byte("works!")
+	addTx := makeSet(key, value)
+	removeTx := makeRemove(key)
+	queryTx := makeQuery(key)
+
+	// need to commit append before it shows in queries
+	append := app.AppendTx(addTx)
+	assert.True(append.IsOK(), append.Log)
+	info = app.Info()
+	assert.Equal("size:0", info)
+	query := app.Query(queryTx)
+	assert.True(query.IsOK(), query.Log)
+	assert.Equal([]byte(nil), query.Data)
+
+	com = app.Commit()
+	hash := com.Data
+	assert.NotEqual(t, nil, hash)
+	info = app.Info()
+	assert.Equal("size:1", info)
+	query = app.Query(queryTx)
+	assert.True(query.IsOK(), query.Log)
+	assert.Equal(value, query.Data)
+
+	// modifying check has no effect
+	check := app.CheckTx(removeTx)
+	assert.True(check.IsOK(), check.Log)
+	com = app.Commit()
+	assert.True(com.IsOK(), com.Log)
+	hash2 := com.Data
+	assert.Equal(hash, hash2)
+	info = app.Info()
+	assert.Equal("size:1", info)
+
+	// proofs come from the last commited state, not working state
+	append = app.AppendTx(removeTx)
+	assert.True(append.IsOK(), append.Log)
+	proof := app.Proof(key)
+	if assert.NotEmpty(proof.Data) {
+		loaded, err := merkle.LoadProof(proof.Data)
+		if assert.Nil(err) {
+			assert.True(loaded.Valid())
+			assert.Equal(hash, loaded.Root())
+			assert.Equal(key, loaded.Key())
+			assert.Equal(value, loaded.Value())
+		}
+	}
+
+	// commit remove actually removes it now
+	com = app.Commit()
+	assert.True(com.IsOK(), com.Log)
+	hash3 := com.Data
+	assert.NotEqual(hash, hash3)
+	info = app.Info()
+	assert.Equal("size:0", info)
+
+	// nothing here...
+	query = app.Query(queryTx)
+	assert.True(query.IsOK(), query.Log)
+	assert.Equal([]byte(nil), query.Data)
+	proof = app.Proof(key)
+	assert.Empty(proof.Data)
+}

--- a/app/state.go
+++ b/app/state.go
@@ -1,0 +1,42 @@
+package app
+
+import merkle "github.com/tendermint/go-merkle"
+
+// State represents the app states, separating the commited state (for queries)
+// from the working state (for CheckTx and AppendTx)
+type State struct {
+	committed merkle.Tree
+	appendTx  merkle.Tree
+	checkTx   merkle.Tree
+}
+
+func NewState(tree merkle.Tree) State {
+	return State{
+		committed: tree,
+		appendTx:  tree.Copy(),
+		checkTx:   tree.Copy(),
+	}
+}
+
+func (s State) Committed() merkle.Tree {
+	return s.committed
+}
+
+func (s State) Append() merkle.Tree {
+	return s.appendTx
+}
+
+func (s State) Check() merkle.Tree {
+	return s.checkTx
+}
+
+// Commit stores the current Append() state as committed
+// starts new Append/Check state, and
+// returns the hash for the commit
+func (s *State) Commit() []byte {
+	hash := s.appendTx.Save()
+	s.committed = s.appendTx
+	s.appendTx = s.committed.Copy()
+	s.checkTx = s.committed.Copy()
+	return hash
+}

--- a/app/state.go
+++ b/app/state.go
@@ -34,7 +34,8 @@ func (s State) Check() merkle.Tree {
 // starts new Append/Check state, and
 // returns the hash for the commit
 func (s *State) Commit() []byte {
-	hash := s.appendTx.Save()
+	// TODO: use save, broken for now, cuz it requires a backing db
+	hash := s.appendTx.Hash()
 	s.committed = s.appendTx
 	s.appendTx = s.committed.Copy()
 	s.checkTx = s.committed.Copy()

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: cf5040883846897ba61ac4df2d746c12991dca32d3b6701221cc059d505788db
-updated: 2016-11-15T13:07:25.904960096-05:00
+hash: a686f5197dbdf8e6d7f36255be361950d837927f9a128362b3960b2631e08239
+updated: 2017-01-09T21:26:37.809726042+01:00
 imports:
 - name: github.com/go-stack/stack
   version: 100eb0c0a9c5b306ca2fb4f165df21d80ada4b82
@@ -9,10 +9,17 @@ imports:
   - proto
 - name: github.com/golang/snappy
   version: d9eb7a3d35ec988b8585d4a0068e462c27d28380
+- name: github.com/jmhodges/levigo
+  version: c42d9e0ca023e2198120196f842701bb4c55d7b9
 - name: github.com/mattn/go-colorable
   version: ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8
 - name: github.com/mattn/go-isatty
   version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
+- name: github.com/stretchr/testify
+  version: 69483b4bd14f5845b5a1e55bca19e954e827f1d0
+  subpackages:
+  - assert
+  - require
 - name: github.com/syndtr/goleveldb
   version: 6ae1797c0b42b9323fc27ff7dcf568df88f2f33d
   subpackages:
@@ -80,4 +87,12 @@ imports:
   - naming
   - peer
   - transport
-testImports: []
+testImports:
+- name: github.com/davecgh/go-spew
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
+  subpackages:
+  - spew
+- name: github.com/pmezard/go-difflib
+  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
+  subpackages:
+  - difflib

--- a/glide.lock
+++ b/glide.lock
@@ -33,11 +33,11 @@ imports:
   subpackages:
   - upnp
 - name: github.com/tendermint/go-db
-  version: 31fdd21c7eaeed53e0ea7ca597fb1e960e2988a5
+  version: 2645626c33d8702739e52a61a55d705c2dfe4530
 - name: github.com/tendermint/go-logger
   version: cefb3a45c0bf3c493a04e9bcd9b1540528be59f2
 - name: github.com/tendermint/go-merkle
-  version: 05042c6ab9cad51d12e4cecf717ae68e3b1409a8
+  version: 1bc9a24706d715cd45403593c6d0a870d70011bb
 - name: github.com/tendermint/go-wire
   version: 3b0adbc86ed8425eaed98516165b6788d9f4de7a
 - name: github.com/tendermint/log15

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,3 +7,8 @@ import:
 - package: github.com/tendermint/tmsp
   subpackages:
   - server
+- package: github.com/stretchr/testify
+  version: ^1.1.4
+  subpackages:
+  - assert
+  - require


### PR DESCRIPTION
Expose proof in merkleeyes app.
Add tests.
Query/proofs from committed states, not current AppendTx (needed to actually validate hash against a block header).

@jaekwon Part of the additions for https://github.com/tendermint/tendermint/issues/355