### PR TITLE
Experimental: duplicate tree missing orphans problem.

### DIFF
--- a/tests/tendermint/kill-tendermerk.sh
+++ b/tests/tendermint/kill-tendermerk.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+TPID=`pidof tendermint`
+MPID=`pidof merkleeyes`
+
+if [ -n "$TPID" ]; then 
+    kill $TPID
+fi
+
+if [ -n "$MPID" ]; then 
+    kill $MPID
+fi

--- a/tests/tendermint/kill-tendermerk.sh
+++ b/tests/tendermint/kill-tendermerk.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 
-TPID=`pidof tendermint`
-MPID=`pidof merkleeyes`
+killall tendermint
+killall merkleeyes
 
-if [ -n "$TPID" ]; then 
-    kill $TPID
-fi
-
-if [ -n "$MPID" ]; then 
-    kill $MPID
-fi

--- a/tests/tendermint/orphans.sh
+++ b/tests/tendermint/orphans.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-#key=01036b6579837A272A2B
 key=01036b6579
-key=01045061756C
 
 function get() {
     echo "GET"
@@ -23,7 +21,6 @@ function cas() {
     v2=$2
     echo 0x${r}04${key}0101${v1}0101${v2} 
     curl localhost:46657/broadcast_tx_sync?tx=0x${r}04${key}0101${v1}0101${v2}
-    #curl localhost:46657/broadcast_tx_sync?tx=0x${r}0401220101${v1}0101${v2}
 }
 
 set 00

--- a/tests/tendermint/orphans.sh
+++ b/tests/tendermint/orphans.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#key=01036b6579837A272A2B
+key=01036b6579
+key=01045061756C
+
+function get() {
+    echo "GET"
+    r=$(go run rand.go)
+    curl localhost:46657/broadcast_tx_sync?tx=0x${r}03${key}
+}
+
+function set() {
+    echo "SET $1"
+    r=$(go run rand.go)
+    v=$1
+    curl localhost:46657/broadcast_tx_sync?tx=0x${r}01${key}0101$v
+}
+
+function cas() {
+    echo "CAS $1 $2"
+    r=$(go run rand.go)
+    v1=$1
+    v2=$2
+    echo 0x${r}04${key}0101${v1}0101${v2} 
+    curl localhost:46657/broadcast_tx_sync?tx=0x${r}04${key}0101${v1}0101${v2}
+    #curl localhost:46657/broadcast_tx_sync?tx=0x${r}0401220101${v1}0101${v2}
+}
+
+set 00
+get
+set 00
+set 04
+get
+cas 01 00
+cas 00 01
+set 02
+get 
+cas 00 00
+get
+set 04
+get
+set 04
+get
+cas 02 03
+cas 00 02
+set 01
+get
+set 01
+cas 04 00

--- a/tests/tendermint/orphans_test.sh
+++ b/tests/tendermint/orphans_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+./start-tendermerk.sh
+
+for n in {1..5}; do
+    ./orphans.sh
+done
+
+./kill-tendermerk.sh

--- a/tests/tendermint/rand.go
+++ b/tests/tendermint/rand.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"crypto/rand"
+	"fmt"
+)
+
+func main() {
+	buf := make([]byte, 12)
+	rand.Read(buf)
+	fmt.Printf("%x\n", buf)
+}

--- a/tests/tendermint/start-tendermerk.sh
+++ b/tests/tendermint/start-tendermerk.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+rm -rf orphan-test-db
+merkleeyes start -d orphan-test-db --address=tcp://127.0.0.1:46658 >> merkleeyes.log &
+
+rm -rf ~/.tendermint
+tendermint init
+tendermint node >> tendermint.log &
+
+sleep 4


### PR DESCRIPTION
This fix assumes that the create and copy tree usage is the same
as merkleeyes. That is, after each save, two copies of the
tree are made, and all three copies are accessed.