### PR TITLE
iavl: make Dump testable with Fdump

### DIFF
--- a/iavl/iavl_tree_dump.go
+++ b/iavl/iavl_tree_dump.go
@@ -3,7 +3,8 @@ package iavl
 import (
 	"bytes"
 	"fmt"
-	//"strings"
+	"io"
+	"os"
 
 	wire "github.com/tendermint/go-wire"
 )
@@ -120,10 +121,15 @@ func overallMapping(value []byte) (str string) {
 	return stateMapping(value)
 }
 
-// Dump everything from the database
+// Dump everything from the database to stdout.
 func (t *IAVLTree) Dump(verbose bool, mapping *KeyValueMapping) {
+	t.Fdump(os.Stdout, verbose, mapping)
+}
+
+// Fdump serializes the entire database to the provided io.Writer.
+func (t *IAVLTree) Fdump(w io.Writer, verbose bool, mapping *KeyValueMapping) {
 	if verbose && t.root == nil {
-		fmt.Printf("No root loaded into memory\n")
+		fmt.Fprintf(w, "No root loaded into memory\n")
 	}
 
 	if mapping == nil {
@@ -133,12 +139,12 @@ func (t *IAVLTree) Dump(verbose bool, mapping *KeyValueMapping) {
 	if verbose {
 		stats := t.ndb.db.Stats()
 		for key, value := range stats {
-			fmt.Printf("%s:\n\t%s\n", key, value)
+			fmt.Fprintf(w, "%s:\n\t%s\n", key, value)
 		}
 	}
 
 	iter := t.ndb.db.Iterator()
 	for iter.Next() {
-		fmt.Printf("%s: %s\n", mapping.Key(iter.Key()), mapping.Value(iter.Value()))
+		fmt.Fprintf(w, "%s: %s\n", mapping.Key(iter.Key()), mapping.Value(iter.Value()))
 	}
 }

--- a/iavl/iavl_tree_dump_test.go
+++ b/iavl/iavl_tree_dump_test.go
@@ -1,0 +1,37 @@
+package iavl_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/tendermint/go-wire"
+	"github.com/tendermint/merkleeyes/iavl"
+	"github.com/tendermint/tmlibs/common"
+	"github.com/tendermint/tmlibs/db"
+)
+
+func i2b(i int) []byte {
+	bz := make([]byte, 4)
+	wire.PutInt32(bz, int32(i))
+	return bz
+}
+
+func TestIAVLTreeFdump(t *testing.T) {
+	db := db.NewDB("test", db.MemDBBackendStr, "")
+	tree := iavl.NewIAVLTree(100000, db)
+	for i := 0; i < 1000000; i++ {
+		tree.Set(i2b(int(common.RandInt32())), nil)
+		if i > 990000 && i%1000 == 999 {
+			tree.Save()
+		}
+	}
+	tree.Save()
+
+	// insert lots of info and store the bytes
+	for i := 0; i < 200; i++ {
+		key, value := common.RandStr(20), common.RandStr(200)
+		tree.Set([]byte(key), []byte(value))
+	}
+
+	tree.Fdump(ioutil.Discard, true, nil)
+}


### PR DESCRIPTION
Make Dump testable by making Fdump that takes in
an io.Writer instead. Dump in the past always
pushed output to stdout so testing this was
impossible without hijacking os.Stdout.