### PR TITLE
iavl: use build tag gcc to run CLevelDB benchmarks appropriately

### DIFF
--- a/iavl/iavl_test.go
+++ b/iavl/iavl_test.go
@@ -584,51 +584,24 @@ func TestIAVLTreeProof(t *testing.T) {
 	}
 }
 
-func BenchmarkImmutableAvlTreeCLevelDB(b *testing.B) {
-	b.StopTimer()
-
-	db := db.NewDB("test", db.CLevelDBBackendStr, "./")
-	t := NewIAVLTree(100000, db)
-	// for i := 0; i < 10000000; i++ {
-	for i := 0; i < 1000000; i++ {
-		// for i := 0; i < 1000; i++ {
-		t.Set(i2b(int(RandInt32())), nil)
-		if i > 990000 && i%1000 == 999 {
-			t.Save()
-		}
-	}
-	t.Save()
-
-	fmt.Println("ok, starting")
-
-	runtime.GC()
-
-	b.StartTimer()
-	for i := 0; i < b.N; i++ {
-		ri := i2b(int(RandInt32()))
-		t.Set(ri, nil)
-		t.Remove(ri)
-		if i%100 == 99 {
-			t.Save()
-		}
-	}
-
-	db.Close()
+func BenchmarkImmutableAvlTreeMemDB(b *testing.B) {
+	db := db.NewDB("test", db.MemDBBackendStr, "")
+	benchmarkImmutableAvlTreeWithDB(b, db)
 }
 
-func BenchmarkImmutableAvlTreeMemDB(b *testing.B) {
+func benchmarkImmutableAvlTreeWithDB(b *testing.B, db db.DB) {
+	defer db.Close()
+
 	b.StopTimer()
 
-	db := db.NewDB("test", db.MemDBBackendStr, "")
 	t := NewIAVLTree(100000, db)
-	// for i := 0; i < 10000000; i++ {
 	for i := 0; i < 1000000; i++ {
-		// for i := 0; i < 1000; i++ {
 		t.Set(i2b(int(RandInt32())), nil)
 		if i > 990000 && i%1000 == 999 {
 			t.Save()
 		}
 	}
+	b.ReportAllocs()
 	t.Save()
 
 	fmt.Println("ok, starting")
@@ -644,6 +617,4 @@ func BenchmarkImmutableAvlTreeMemDB(b *testing.B) {
 			t.Save()
 		}
 	}
-
-	db.Close()
 }

--- a/iavl/iavl_with_gcc_test.go
+++ b/iavl/iavl_with_gcc_test.go
@@ -1,0 +1,18 @@
+// +build gcc
+
+// This file exists because some of the DBs e.g CLevelDB
+// require gcc as the compiler before they can ran otherwise
+// we'll encounter crashes such as in https://github.com/tendermint/merkleeyes/issues/39
+
+package iavl
+
+import (
+	"testing"
+
+	"github.com/tendermint/tmlibs/db"
+)
+
+func BenchmarkImmutableAvlTreeCLevelDB(b *testing.B) {
+	db := db.NewDB("test", db.CLevelDBBackendStr, "./")
+	benchmarkImmutableAvlTreeWithDB(b, db)
+}


### PR DESCRIPTION
- Use build tag
+build gcc
to isolate and guard and only run benchmarks
such as:
* BenchmarkImmutableAvlTreeCLevelDB
in a separate file on systems that use gcc as the compiler,
otherwise benchmarks will just crash and noisly mud the test output,
say for example on my Mac and others' when running benchmarks.

- Also refactored and moved the common benchmark code into
a helper `benchmarkImmutableAvlTreeWithDB` that the various
benchmarks can invoke with the desired DB i.e
```go
db := db.NewDB("test", db.MemDBBackendStr, "")
benchmarkImmutableAvlTreeWithDB(b, db)
```

Fixes https://github.com/tendermint/merkleeyes/issues/39